### PR TITLE
Current formatting is misleading.

### DIFF
--- a/guides/Affliction/Stats.html
+++ b/guides/Affliction/Stats.html
@@ -11,7 +11,7 @@
   <div class="center">
       <h2>Affliction ST Stat Weights:</h2>
   </div>
-  These sims are ran with a base Heroic profile:
+  These sims are ran with a base Heroic profile:<br>
   Mastery: 1.5 <br>
   Haste: 1.5<br>
   Crit: 1.3 <br>


### PR DESCRIPTION
Easy to miss Mastery when it's displayed on the same  line as "These sims are ran with a base Heroic profile"